### PR TITLE
A couple adjustments to prevent flickering on Drop style ...

### DIFF
--- a/Source/MMProgressHUD+Animations.m
+++ b/Source/MMProgressHUD+Animations.m
@@ -81,6 +81,7 @@
     double newAngle = arc4random_uniform(1000)/1000.f*M_2_PI-(M_2_PI)/2.f;
     CGPoint newPosition = CGPointMake(self.hud.layer.position.x, self.frame.size.height + self.hud.frame.size.height);
     
+    
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
     {
@@ -586,6 +587,12 @@
         
         blockSelf.queuedShowAnimation = nil;
         
+        if (blockSelf.showAnimationCompletion != nil) {
+            blockSelf.showAnimationCompletion();
+            blockSelf.showAnimationCompletion = nil;
+        }
+        
+        
         if (blockSelf.queuedDismissAnimation != nil) {
             [blockSelf _executeDismissAnimation:blockSelf.queuedDismissAnimation];
             blockSelf.queuedDismissAnimation = nil;
@@ -617,6 +624,7 @@
         
         if (blockSelf.dismissAnimationCompletion != nil) {
             blockSelf.dismissAnimationCompletion();
+            blockSelf.dismissAnimationCompletion = nil;
         }
         
         [blockSelf.hud removeFromSuperview];

--- a/Source/MMProgressHUD.h
+++ b/Source/MMProgressHUD.h
@@ -121,6 +121,12 @@ This message will be presented to the user when a cancelBlock is present after t
  */
 @property (nonatomic, copy) void(^dismissAnimationCompletion)(void);
 
+/** A block to be executed as soon as the show animation has completed and the HUD is fully on screen.
+ 
+ This block will be automatically released and nil'd after firing and is guaranteed to fire only once.
+ */
+@property (nonatomic, copy) void(^showAnimationCompletion)(void);
+
 /** The HUD that is displaying all information. */
 @property (nonatomic, strong) MMHud *hud;
 

--- a/Source/MMProgressHUD.m
+++ b/Source/MMProgressHUD.m
@@ -537,10 +537,9 @@ CGSize const MMProgressHUDDefaultImageSize = {37.f, 37.f};
     if (!self.queuedDismissAnimation) {
         [self _fadeOutAndCleanUp];
     } else {
-        void (^oldCompletion)(void) = [self.dismissAnimationCompletion copy];
-        self.dismissAnimationCompletion = ^{
-            MMProgressHUD *self = weakSelf;
-            [self _fadeOutAndCleanUp];
+        void (^oldCompletion)(void) = [self.showAnimationCompletion copy];
+        self.showAnimationCompletion = ^{
+            [weakSelf _fadeOutAndCleanUp];
             if (oldCompletion)
                 oldCompletion();
         };
@@ -549,8 +548,8 @@ CGSize const MMProgressHUDDefaultImageSize = {37.f, 37.f};
 
 - (void)_fadeOutAndCleanUp
 {
-    CGFloat duration = (self.presentationStyle == MMProgressHUDPresentationStyleNone) ? 0.f : MMProgressHUDAnimateOutDurationLong;
-    CGFloat delay = (self.presentationStyle == MMProgressHUDPresentationStyleDrop) ? MMProgressHUDAnimateOutDurationShort : 0.f;
+    CGFloat duration = (self.presentationStyle == MMProgressHUDPresentationStyleNone) ? 0.f : MMProgressHUDAnimateOutDurationLong;// - 0.15;
+    CGFloat delay = 0.0;//(self.presentationStyle == MMProgressHUDPresentationStyleDrop) ? MMProgressHUDAnimateOutDurationShort : 0.f;
     
     [UIView
      animateWithDuration:duration


### PR DESCRIPTION
...when dismiss is called too soon.

There are two issues that occur when dismiss is called before show is complete. The first is the setting of the hud's position and transform immediately on calling dismiss which causes it to disappear for a moment until the dismiss animation kicks in.

The second is the completion block for the background fade which cleans up and hides the UIWindow containing the HUD causing it to disappear before it's off screen.   I've put in a delay if progress < 0.  It's a touch hack-ish but it's quite a sophisticated system and I'm hoping you might have a better solution :)

Love the drop-style by the way - perfect for my client project!  I'll let you know the app when it's out of NDA :)
