### PR TITLE
Update podspec to include MMProgressView-Protocol.h in the public header files

### DIFF
--- a/MMProgressHUD.podspec
+++ b/MMProgressHUD.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   }
   s.platform     = :ios, '5.0'
   s.source_files = 'Source/*.{h,m}'
-  s.public_header_files = 'Source/{MMProgressHUDOverlayView,MMProgressHUD,MMHud}.h'
+  s.public_header_files = 'Source/{MMProgressHUDOverlayView,MMProgressHUD,MMHud,MMProgressView-Protocol}.h'
   s.frameworks = 'QuartzCore', 'CoreGraphics'
   s.requires_arc = true
 end


### PR DESCRIPTION
It's currently not possible to create a custom progress view when using MMProgressHUD from cocoapods, because MMProgressView-Protocol.h is not part of the public header files.
