### PR TITLE
UIViewControllerHierarchyInconsistency solved by defensive check

### DIFF
--- a/Source/MMProgressHUD.m
+++ b/Source/MMProgressHUD.m
@@ -622,6 +622,7 @@ CGSize const MMProgressHUDDefaultImageSize = {37.f, 37.f};
          self.hud.completionState = MMProgressHUDCompletionStateNone;
          [self.presentationViewController removeFromParentViewController];
          [self removeFromSuperview];
+         self.presentationViewController.view = nil;
          self.presentationViewController = nil;
          
          [self.window setHidden:YES], self.window = nil;


### PR DESCRIPTION
We keet receiving UIViewControllerHierarchyInconsistency exception on previous version when calling #show method.

We solve that by adding these lines. They are harmless and it would help others if you include them.

Thanks!
