### PR TITLE
Adding a new property to allow changing animation images globally.

### DIFF
--- a/Source/MMProgressHUD+Class.m
+++ b/Source/MMProgressHUD+Class.m
@@ -37,6 +37,10 @@
     [hud setDisplayStyle:style];
 }
 
++ (void)setSpinAnimationImages:(NSArray *)animationImages {
+    [[MMProgressHUD sharedHUD] setSpinAnimationImages:animationImages];
+}
+
 //updates
 + (void)updateStatus:(NSString *)status {
     [MMProgressHUD updateTitle:nil status:status]; 

--- a/Source/MMProgressHUD.h
+++ b/Source/MMProgressHUD.h
@@ -101,6 +101,12 @@ This message will be presented to the user when a cancelBlock is present after t
  */
 @property (nonatomic, strong) UIImage *successImage;
 
+/** The array of images to be used for pending. Persistent across show calls.
+ 
+ The image size is currently fixed to 100x100. The image will scale to fit if the image is larger than 100x100, otherwise it will remain centered.
+ */
+@property (nonatomic, strong) NSArray *spinAnimationImages;
+
 /** A block to be executed when the progress fed to the HUD reaches 100%.
  
  This block will also fire when the progress exceeds 100%. This block was designed to be used by setting up your completion call before calling show: on the HUD, then simply feed progress updates to the HUD via the updateProgress: methods. When progress reaches 100%, this block is automatically fired. This block is automatically released after firing and is guaranteed to only fire once.
@@ -505,6 +511,12 @@ This message will be presented to the user when a cancelBlock is present after t
  @param displayStyle Style to set the HUD to.
  */
 + (void)setDisplayStyle:(MMProgressHUDDisplayStyle)displayStyle;
+
+/** Sets the animation images of the current shared instance.
+
+ @param animationImages UIImages to set animation of HUD.
+ */
++ (void)setSpinAnimationImages:(NSArray *)animationImages;
 
 @end
 

--- a/Source/MMProgressHUD.m
+++ b/Source/MMProgressHUD.m
@@ -103,6 +103,12 @@ CGSize const MMProgressHUDDefaultImageSize = {37.f, 37.f};
     else if (images.count > 0) {
         self.animationImages = images;
     }
+    else if (self.spinAnimationImages.count == 1) {
+        self.image = self.spinAnimationImages[0];
+    }
+    else if (self.spinAnimationImages.count > 0) {
+        self.animationImages = self.spinAnimationImages;
+    }
     
     self.cancelBlock = cancelBlock;
     self.title = title;


### PR DESCRIPTION
Made an easy change to achieve what I want here in issue #35 .
User now can easily set global animation images by...
```objective-c
// ... either use class method ...
[MMProgressHUD setSpinAnimationImages:images];
// ...or set current instance's property
[MMProgressHUD sharedHUD].spinAnimationImages = images;
```
Hope you feel it's good to merge :laughing: 