### PR TITLE
Added attributes to allow MMProgressHUD to compile when app contains …

### DIFF
--- a/Source/MMProgressHUD+Animations.m
+++ b/Source/MMProgressHUD+Animations.m
@@ -154,7 +154,7 @@
     [CATransaction commit];
 }
 
-- (void)_showWithSwingInAnimationFromLeft:(BOOL)fromLeft {
+- (void)_showWithSwingInAnimationFromLeft:(BOOL)fromLeft NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions."){
     self.hud.layer.anchorPoint = CGPointMake(0.5f, 0.0f);
     
     [CATransaction begin];
@@ -414,7 +414,7 @@
     return animationGroup;
 }
 
-- (CAAnimation *)_swingInAnimationFromLeft:(BOOL)fromLeft {
+- (CAAnimation *)_swingInAnimationFromLeft:(BOOL)fromLeft NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions."){
     CAKeyframeAnimation *rotate = [CAKeyframeAnimation animationWithKeyPath:@"transform.rotation"];
     
     CGPoint endPoint = [self _windowCenterForHUDAnchor:self.hud.layer.anchorPoint];

--- a/Source/MMProgressHUDViewController.m
+++ b/Source/MMProgressHUDViewController.m
@@ -113,11 +113,11 @@ _Pragma("clang diagnostic pop") \
     MMHudLog(@"dealloc");
 }
 
-- (UIStatusBarStyle)preferredStatusBarStyle{
+- (UIStatusBarStyle)preferredStatusBarStyle NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions."){
     return [[UIApplication sharedApplication] statusBarStyle];
 }
 
-- (BOOL)prefersStatusBarHidden{
+- (BOOL)prefersStatusBarHidden NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions."){
     return [[UIApplication sharedApplication] isStatusBarHidden];
 }
 

--- a/Source/MMProgressHUDWindow.m
+++ b/Source/MMProgressHUDWindow.m
@@ -41,7 +41,7 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
-- (UIWindow *)oldWindow {
+- (UIWindow *)oldWindow NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions."){
     if (_oldWindow == nil) {
         self.oldWindow = [[[UIApplication sharedApplication] windows] firstObject];
     }


### PR DESCRIPTION
…an extension.

Recently worked on a project that had an old version (0.2.3) of MMProgressHUD. Upon updating to the latest version (0.3.1) of MMProgressHUD, the project no longer compiled because MMProgressHUD contains a number of UIApplication methods which you cannot use if your project contains an extension. After doing a bit of research, I took a page from the AFNetworking team and added attributes to the offending methods which now allows MMProgressHUD to successfully compile.

Please consider using my update for those who might be running into similar issues.